### PR TITLE
Add Advisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 
 ## Threads & workflow
 
-- [Advisor](https://github.com/salemsayed/bb-plugin-advisor) — Independent second-model review for coding threads: a required `advisor_review` tool before final answers, post-turn re-checks with persisted finding chains that only an Advisor re-check can close, and per-machine reviewer model selection.
+- [bb-plugin-advisor](https://github.com/salemsayed/bb-plugin-advisor) — reviews a coding thread with a second model in a hidden reviewer thread; a pre-final agent tool plus post-turn review, with findings that re-raise across turns until the reviewer re-checks and closes them.
 - [bb-plugin-bus](https://github.com/MGrin/bb-plugin-bus) — peer messaging between threads; addressed sends wake the recipient with a real turn, so no listener process is needed.
 - [bb-plugin-auto-sections](https://github.com/benegessarit/bb-plugin-auto-sections) — files task-keyed threads into sidebar sections automatically.
 - [thread-organizer](https://github.com/brsbl/bb-plugins) — organize threads in the sidebar.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 
 ## Threads & workflow
 
+- [Advisor](https://github.com/salemsayed/bb-plugin-advisor) — Independent second-model review for coding threads: a required `advisor_review` tool before final answers, post-turn re-checks with persisted finding chains that only an Advisor re-check can close, and per-machine reviewer model selection.
 - [bb-plugin-bus](https://github.com/MGrin/bb-plugin-bus) — peer messaging between threads; addressed sends wake the recipient with a real turn, so no listener process is needed.
 - [bb-plugin-auto-sections](https://github.com/benegessarit/bb-plugin-auto-sections) — files task-keyed threads into sidebar sections automatically.
 - [thread-organizer](https://github.com/brsbl/bb-plugins) — organize threads in the sidebar.


### PR DESCRIPTION
## What

Add [Advisor](https://github.com/salemsayed/bb-plugin-advisor) to the Threads & workflow section.

## Why

Advisor is an open-source bb plugin that adds independent second-model review before final answers, post-turn re-checks, and persistent finding chains.

## Validation

- Kept the entry to one factual sentence
- Linked directly to the public plugin repository
- Added it to the matching Threads & workflow category
- Verified the plugin manifest and public documentation
