### PR TITLE
docs: add bb-plugin-fontsize

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 - [bb-plugin-ayu](https://github.com/vburojevic/bb-plugin-ayu) — ayu themes plus a palette explorer.
 - [bb-plugin-sidebar-sync](https://github.com/MGrin/bb-plugin-sidebar-sync) — keeps the sidebar arrangement — nav order, hidden rows, collapsed sections — the same in every bb UI; width and open state stay per-device.
 - [ds4](https://github.com/patleeman/bb-plugins) — design-system theming.
+- [bb-plugin-fontsize](https://github.com/jmporchet/bb-plugin-fontsize) — scale the whole bb interface from a button in the sidebar footer.
 
 ## Fun
 


### PR DESCRIPTION
bb has no built-in interface font-size setting — Settings → Appearance only covers themes and palettes. This plugin adds one, without forking bb.