### PR TITLE
Discover plugins, not repos — the sweep was losing 25 of them

### DIFF
--- a/.github/workflows/discover.yml
+++ b/.github/workflows/discover.yml
@@ -6,9 +6,16 @@ name: discover unlisted plugins
 # an entry needs a human sentence and the right section, and an auto-appended
 # list of repo blurbs would be a worse directory than none.
 
+# DAILY, not weekly, and the reason is a scheduling bug rather than a wish for
+# more sweeps. What ACTS on this issue is the Monday upkeep pass of the
+# repo-steward automation, whose first Monday tick is 00:20 Asia/Makassar =
+# Sunday 16:20 UTC — seventeen hours BEFORE a Monday-09:00-UTC sweep. So every
+# candidate the sweep found sat unread for a full week, every week, and the list
+# looked stale while the discovery was working fine. A daily sweep removes the
+# coupling: whenever triage runs, the issue it reads is at most a day old.
 on:
   schedule:
-    - cron: "0 9 * * 1" # Mondays, 09:00 UTC
+    - cron: "0 6 * * *" # daily, 06:00 UTC
   workflow_dispatch: {}
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+# repo-steward copies the canonical awesome-triage workflow here from ~/Dev/dotfiles
+# at run time. Tracking it would make a second copy that drifts from the original.
+.bb/

--- a/README.md
+++ b/README.md
@@ -6,12 +6,22 @@ bb ships 13 official plugins bundled inside the app and [deliberately has no rem
 marketplace](https://github.com/get-bb/bb/pull/737), so third-party plugins are found by
 word of mouth. This list is the missing directory.
 
-**Everything here installs the same way** — there are no bb plugins on npm yet
-([`@bb/plugin-sdk` isn't published](https://github.com/get-bb/bb/issues/1134)):
+**Two install forms.** Everything here installs from git:
 
 ```sh
 bb plugin install git:https://github.com/<owner>/<repo>.git@main
 ```
+
+Some now publish to npm as well — [16 packages carry the `bb-plugin`
+keyword](https://www.npmjs.com/search?q=keywords:bb-plugin) as of 2026-08-12 — and where an
+entry lists one, that is the shorter route:
+
+```sh
+bb plugin install npm:<package>
+```
+
+([`@bb/plugin-sdk` itself is still unpublished](https://github.com/get-bb/bb/issues/1134);
+plugins vendor it. That blocks the SDK, not the plugins.)
 
 Plugins are full-trust code running in the bb server. Read the source before installing.
 
@@ -77,7 +87,7 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 ## Integrations
 
 - [bb-plugin-linear](https://github.com/thonythony/bb-plugin-linear) — Linear issues, start a thread from one.
-- [linear](https://github.com/galligan/bb-mate) — an independent Linear integration.
+- [linear](https://github.com/galligan/bb-plugin-studio/tree/main/plugins/linear) — search Linear issues from the prompt box and attach agent-ready context.
 - [telemetry](https://github.com/patleeman/bb-plugins) — usage telemetry.
 - [bb-plugin-exec-tracking](https://github.com/pixexid/llm-collab) — records provider/model/reasoning evidence per run.
 - [bb-plugin-argocd](https://github.com/Willhong/bb-plugin-argocd) — read-only Argo CD browser: application sync and health, managed resources, deploy history and pod logs, with agent tools and a `bb argocd` CLI.
@@ -97,7 +107,7 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 
 ## Authoring tools
 
-- [bb-mate](https://github.com/galligan/bb-mate) — fixture-driven plugin authoring workbench; the only bb tooling published to npm.
+- [bb-mate](https://github.com/galligan/bb-plugin-studio/tree/main/plugins/mate) — fixture-driven plugin authoring workbench, run against a supervised bb-mate runtime.
 - [bb-smithers-workflows](https://github.com/benvenker/bb-smithers-workflows) — plugin verification and release-gate workflows.
 - [create-plugin / validate-plugin-artifacts](https://github.com/brsbl/bb-plugins) — scaffolding and artifact validation scripts.
 

--- a/discovery-ledger.json
+++ b/discovery-ledger.json
@@ -1,0 +1,25 @@
+{
+  "_readme": [
+    "Judgements the weekly sweep must not make again. Without this file scripts/discover.mjs",
+    "re-proposes everything anyone ever decided against, once a week, forever.",
+    "",
+    "declined[] — a plugin that was looked at and deliberately not listed. `plugin` is either",
+    "  'owner/repo' for a single-plugin repo or 'owner/repo/plugins/name' for one inside a",
+    "  monorepo, lowercase. A reason is required: the next person to read this is deciding",
+    "  whether the decision still holds, and 'no' on its own does not tell them.",
+    "",
+    "listedAs[] — a plugin that IS in README.md under a name the sweep cannot match to its",
+    "  directory. Only needed when the entry text and the folder disagree.",
+    "",
+    "Nothing here is permanent. A plugin declined for being unfinished belongs in the list once",
+    "it is finished — delete the entry and the next sweep will propose it again."
+  ],
+  "declined": [
+    {
+      "plugin": "smsunarto/bb-plugins/plugins/pr-walkthrough",
+      "reason": "Its own package.json description opens 'WORK IN PROGRESS — unfinished and unsupported'. The author is saying not to depend on it yet; the list should not say otherwise. Remove this entry when that wording goes.",
+      "at": "2026-08-12"
+    }
+  ],
+  "listedAs": []
+}

--- a/scripts/discover.mjs
+++ b/scripts/discover.mjs
@@ -3,20 +3,44 @@
 //
 // WHY: the list is hand-compiled, and the whole point of it is that nobody can
 // see what exists. A directory that only grows when someone remembers to send a
-// link has the same problem it was built to solve — this repo's own README
-// notes two independent Linear plugins and a system monitor duplicating an open
-// PR, all because discovery was manual.
+// link has the same problem it was built to solve.
 //
-// HOW IT LOOKS: three searches that fail in different ways, so one missing a
-// repo does not hide it. Name-prefix finds the conventional `bb-plugin-*`;
-// topic finds anyone who tagged theirs; code search finds plugins named
-// something else entirely, which the other two structurally cannot.
+// THE UNIT IS A PLUGIN, NOT A REPO. That is the whole difference between this
+// version and the first one. v1 asked "is this repo a plugin?" and answered it
+// from the repo's ROOT package.json, which is wrong twice over:
 //
-// WHAT COUNTS: the README's own bar — package.json has a `bb` key, or the code
-// imports @bb/plugin-sdk. Nothing is added on the strength of a repo name.
+//   - A plugin monorepo has no bb key at the root. smsunarto/bb-plugins (9
+//     plugins) and MateoCerquetella/bb-plugins (2) are both tagged
+//     `topic:bb-plugin`, were both found by the topic search, and were both
+//     thrown away as "not a plugin" — 11 plugins lost to a manifest path.
+//   - An ALREADY-LISTED monorepo hid every plugin added to it afterwards,
+//     because "already listed" was decided per repo. patleeman/bb-plugins
+//     gained bb-plugin-emoji-react and bb-plugin-grove, jssblck/bb-plugins
+//     gained plugin-goal, and the sweep could not have reported any of them.
+//
+// So: enumerate the manifests inside a repo, and compare each plugin against
+// the entries of the README rather than comparing repo URLs.
+//
+// FOUR SOURCES, failing in different ways so one missing a plugin does not hide
+// it: name-prefix finds the conventional `bb-plugin-*`; topics find anyone who
+// tagged theirs; description search finds plugins named something else entirely
+// (SawyerHood/bb-slop-cop has a real bb key and matches no naming convention —
+// v1's name gate dropped it before ever reading its manifest); npm finds the
+// ones now published there, which is a channel that did not exist when v1 was
+// written.
+//
+// WHAT COUNTS: the README's own bar — a manifest with a `bb` key, or one that
+// depends on @bb/plugin-sdk. Nothing is added on the strength of a repo name.
+//
+// WHAT STAYS DECLINED: `discovery-ledger.json`. Without it the sweep re-proposes
+// everything anyone ever decided against — bb-plugin-attention was removed from
+// the list deliberately and came back in the next report. A judgement that is
+// not written down is a judgement that gets made again every week.
 //
 // Prints a markdown report on stdout and exits 0 with NO output when there is
 // nothing new, so the workflow can stay quiet on a normal week.
+
+import { readFile } from "node:fs/promises";
 
 const TOKEN = process.env.GITHUB_TOKEN;
 if (!TOKEN) {
@@ -47,125 +71,273 @@ const SEARCHES = [
   { label: "name", q: "bb-plugin in:name", pages: 3, sort: "updated" },
   { label: "topic", q: "topic:bb-plugin", pages: 1 },
   { label: "topic-getbb", q: "topic:getbb", pages: 1 },
+  // Finds plugins whose repo is not named bb-plugin-* and who never tagged it.
+  // This is the search that would have caught bb-slop-cop.
+  { label: "description", q: '"bb plugin" in:description,readme', pages: 2, sort: "updated" },
 ];
 
 async function searchRepos() {
   const found = new Map(); // full_name -> {repo, how:Set}
+  const add = (r, label) => {
+    if (!r?.full_name) return;
+    const e = found.get(r.full_name) ?? { repo: r, how: new Set() };
+    e.how.add(label);
+    found.set(r.full_name, e);
+  };
+
   for (const s of SEARCHES) {
     for (let page = 1; page <= (s.pages ?? 1); page++) {
       const sort = s.sort ? `&sort=${s.sort}&order=desc` : "";
       const data = await gh(`/search/repositories?per_page=100&page=${page}${sort}&q=${encodeURIComponent(s.q)}`);
       const items = data?.items ?? [];
-      for (const r of items) {
-        const e = found.get(r.full_name) ?? { repo: r, how: new Set() };
-        e.how.add(s.label);
-        found.set(r.full_name, e);
-      }
-      if (items.length < 100) break;   // last page
+      for (const r of items) add(r, s.label);
+      if (items.length < 100) break; // last page
     }
   }
+
   // Code search is the one that finds plugins NOT named bb-plugin-*, which is
-  // exactly the blind spot of the other two. It needs its own Accept header and
-  // is the flakiest, so a failure here degrades the sweep instead of failing it.
+  // exactly the blind spot of the name search. It needs its own Accept header
+  // and is the flakiest, so a failure here degrades the sweep instead of
+  // failing it.
   try {
     const code = await gh(
       "/search/code?per_page=100&q=" + encodeURIComponent('"@bb/plugin-sdk" in:file filename:package.json'),
       "application/vnd.github.text-match+json",
     );
-    for (const item of code?.items ?? []) {
-      const r = item.repository;
-      if (!r) continue;
-      const e = found.get(r.full_name) ?? { repo: r, how: new Set() };
-      e.how.add("code");
-      found.set(r.full_name, e);
-    }
+    for (const item of code?.items ?? []) add(item.repository, "code");
   } catch (e) {
     console.error(`discover: code search unavailable (${e.message}) — continuing with repo searches`);
   }
+
+  // npm. Plugins publish there now — `bb plugin install npm:bb-plugin-taskboard`
+  // is the install line in half the Discord announcements — and the keyword
+  // search is precise in a way the text search is not: `keywords:bb-plugin`
+  // returns 16 packages, `text=bb-plugin` returns 260,000. Each package carries
+  // a repository URL, which is what we actually want.
+  try {
+    const res = await fetch("https://registry.npmjs.org/-/v1/search?text=keywords:bb-plugin&size=250", {
+      headers: { "user-agent": "awesome-bb-plugins-discover" },
+    });
+    if (!res.ok) throw new Error(`npm search ${res.status}`);
+    const data = await res.json();
+    for (const o of data.objects ?? []) {
+      const url = o.package?.links?.repository ?? o.package?.repository?.url ?? "";
+      const m = url.match(/github\.com[/:]([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?(?:$|[/#])/);
+      if (!m) continue;
+      const fullName = `${m[1]}/${m[2]}`;
+      // A repo the GitHub searches already returned keeps its rich metadata;
+      // one only npm knows about gets a stub, filled in below.
+      if (found.has(fullName)) found.get(fullName).how.add("npm");
+      else found.set(fullName, { repo: { full_name: fullName, stub: true }, how: new Set(["npm"]) });
+    }
+  } catch (e) {
+    console.error(`discover: npm search unavailable (${e.message}) — continuing without it`);
+  }
+
   return found;
 }
 
-/** The README's bar, applied to the repo itself rather than to its name. */
-async function isPlugin(fullName, defaultBranch) {
-  for (const path of ["package.json", "plugin/package.json", "packages/plugin/package.json"]) {
-    const file = await gh(`/repos/${fullName}/contents/${path}?ref=${defaultBranch}`);
-    if (!file?.content) continue;
-    try {
-      const pkg = JSON.parse(Buffer.from(file.content, "base64").toString("utf8"));
-      if (pkg.bb) return { ok: true, why: "package.json has a bb key", desc: pkg.bb?.description ?? null };
-      const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}), ...(pkg.peerDependencies ?? {}) };
-      if (deps["@bb/plugin-sdk"]) return { ok: true, why: "depends on @bb/plugin-sdk", desc: null };
-    } catch {
-      /* unparseable package.json is not a plugin claim */
-    }
-  }
+const isPluginManifest = (pkg) => {
+  if (pkg?.bb) return { ok: true, why: "package.json has a bb key", desc: pkg.bb?.description ?? pkg.description ?? null };
+  const deps = { ...(pkg?.dependencies ?? {}), ...(pkg?.devDependencies ?? {}), ...(pkg?.peerDependencies ?? {}) };
+  if (deps["@bb/plugin-sdk"]) return { ok: true, why: "depends on @bb/plugin-sdk", desc: pkg?.description ?? null };
   return { ok: false };
+};
+
+const readPkg = async (fullName, path, ref) => {
+  const file = await gh(`/repos/${fullName}/contents/${path}${ref ? `?ref=${ref}` : ""}`);
+  if (!file?.content) return null;
+  try {
+    return JSON.parse(Buffer.from(file.content, "base64").toString("utf8"));
+  } catch {
+    return null; // an unparseable package.json is not a plugin claim
+  }
+};
+
+const listDirs = async (fullName, path, ref) => {
+  const d = await gh(`/repos/${fullName}/contents/${path}${ref ? `?ref=${ref}` : ""}`);
+  return Array.isArray(d) ? d.filter((x) => x.type === "dir").map((x) => x.name) : [];
+};
+
+/**
+ * Every plugin inside a repo, as a list — a monorepo yields many, an ordinary
+ * plugin repo yields one, a repo that only mentions bb yields none.
+ */
+async function findPlugins(fullName, ref) {
+  const units = [];
+  const consider = async (path, dirName) => {
+    const pkg = await readPkg(fullName, path ? `${path}/package.json` : "package.json", ref);
+    if (!pkg) return false;
+    const verdict = isPluginManifest(pkg);
+    if (!verdict.ok) return false;
+    units.push({
+      repo: fullName,
+      path: path || null,
+      // The name a reader would use. Prefer the manifest's own bb name, then
+      // the npm name, then the directory — a directory called `notify` and a
+      // package called `@smsunarto/bb-plugin-notify` are the same plugin, and
+      // the README may have used either.
+      name: pkg.bb?.name ?? pkg.name ?? dirName ?? fullName.split("/")[1],
+      pkgName: pkg.name ?? null,
+      dirName: dirName ?? null,
+      desc: (verdict.desc || "").replace(/\s+/g, " ").trim(),
+      why: verdict.why,
+    });
+    return true;
+  };
+
+  // The root is a plugin in the ordinary case, and is a workspace in the
+  // interesting one. Both are worth checking; neither excludes the other.
+  await consider("", null);
+  await consider("plugin", "plugin");
+
+  for (const container of ["plugins", "packages"]) {
+    const dirs = await listDirs(fullName, container, ref);
+    for (const dir of dirs) await consider(`${container}/${dir}`, dir);
+  }
+  return units;
 }
 
-const readme = await (async () => {
-  const { readFile } = await import("node:fs/promises");
-  return readFile(new URL("../README.md", import.meta.url), "utf8");
-})();
+const norm = (s) =>
+  String(s ?? "")
+    .toLowerCase()
+    .replace(/^@[^/]+\//, "")     // npm scope
+    .replace(/^bb[-_]?plugin[-_]?/, "")
+    .replace(/^plugin[-_]?/, "")
+    .replace(/[^a-z0-9]/g, "");
 
-// Compare by repo, not by entry: several listed plugins live in one monorepo
-// (brsbl/bb-plugins, patleeman/bb-plugins), and re-reporting those every week
-// would train the reader to ignore the report.
-const listed = new Set(
-  [...readme.matchAll(/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)/g)].map(
-    (m) => `${m[1]}/${m[2]}`.toLowerCase(),
-  ),
+const readme = await readFile(new URL("../README.md", import.meta.url), "utf8");
+
+// Entries, not bare URLs. `[excalidraw](https://github.com/patleeman/bb-plugins)`
+// and `[sessions](...same repo...)` are two plugins in one repo, and the only
+// thing distinguishing them is the link TEXT — so that is what gets matched.
+const listedEntries = [...readme.matchAll(/\[([^\]]+)\]\(https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)([^)]*)\)/g)].map(
+  (m) => ({ text: m[1], repo: `${m[2]}/${m[3]}`.toLowerCase(), rest: m[4] ?? "" }),
 );
+const listedRepoNames = new Map(); // repo -> Set of normalised entry names
+for (const e of listedEntries) {
+  if (!listedRepoNames.has(e.repo)) listedRepoNames.set(e.repo, new Set());
+  listedRepoNames.get(e.repo).add(norm(e.text));
+  // A `/tree/main/plugins/gh-stack` link names the plugin by path too.
+  const sub = e.rest.match(/\/(?:tree|blob)\/[^/]+\/(?:plugins|packages)\/([A-Za-z0-9_.-]+)/);
+  if (sub) listedRepoNames.get(e.repo).add(norm(sub[1]));
+}
+
+// Judgements already made. Without this the sweep argues with the maintainer
+// once a week, forever.
+const ledger = await (async () => {
+  try {
+    return JSON.parse(await readFile(new URL("../discovery-ledger.json", import.meta.url), "utf8"));
+  } catch {
+    return { declined: [], listedAs: [] };
+  }
+})();
+const declined = new Set((ledger.declined ?? []).map((d) => (d.plugin ?? d.repo ?? "").toLowerCase()));
+const listedAs = new Set((ledger.listedAs ?? []).map((d) => (d.plugin ?? "").toLowerCase()));
+
+const isListed = (u) => {
+  const key = (u.path ? `${u.repo}/${u.path}` : u.repo).toLowerCase();
+  if (listedAs.has(key)) return true;
+  const names = listedRepoNames.get(u.repo.toLowerCase());
+  if (!names) return false;
+  // A single-plugin repo is listed if the repo is linked at all. A monorepo's
+  // plugin is listed only if some entry names it.
+  if (!u.path) return true;
+  return [u.name, u.pkgName, u.dirName].some((n) => n && names.has(norm(n)));
+};
 
 const found = await searchRepos();
-const stats = { searched: found.size, alreadyListed: 0, notAPlugin: 0, archived: 0 };
+const stats = { repos: found.size, skippedRepos: 0, private: 0, archived: 0, plugins: 0, alreadyListed: 0, declined: 0 };
 const candidates = [];
-for (const [fullName, { repo, how }] of found) {
-  if (listed.has(fullName.toLowerCase())) { stats.alreadyListed++; continue; }
+
+for (const [fullName, { repo: found0, how }] of found) {
+  // npm only gave us a name. Everything below — private, archived, stars, last
+  // push — needs the repo itself.
+  const repo = found0.stub ? ((await gh(`/repos/${fullName}`)) ?? found0) : found0;
+
+  // The sweep runs with a token, so GitHub search happily returns the token
+  // owner's PRIVATE repos — and it did: four of mgrin's own were proposed for
+  // a public directory. An entry pointing at a private repo is a 404 for
+  // everyone but its owner, which is precisely the failure commit fd2338a had
+  // to clean up by hand. Anything not provably public is not a candidate.
+  if (repo.private !== false) { stats.private++; continue; }
   if (repo.archived) { stats.archived++; continue; }
-  if (repo.full_name.toLowerCase() === "get-bb/bb") continue; // bb itself, not a plugin
-  // The name search drags in other ecosystems' "bb-plugin" repos. Verifying all
-  // of them costs three content requests each and hits the rate limit; a repo
-  // vouched for by a topic or by code search skips this filter entirely.
-  const vouched = how.has("topic") || how.has("topic-getbb") || how.has("code");
-  if (!vouched && !/bb[-_]?plugin/i.test(repo.name)) { stats.notAPlugin++; continue; }
-  const verdict = await isPlugin(fullName, repo.default_branch ?? "main");
-  if (!verdict.ok) { stats.notAPlugin++; continue; }
-  candidates.push({
-    fullName,
-    url: repo.html_url,
-    stars: repo.stargazers_count ?? 0,
-    pushed: (repo.pushed_at ?? "").slice(0, 10),
-    desc: (verdict.desc || repo.description || "").replace(/\s+/g, " ").trim(),
-    why: verdict.why,
-    how: [...how].join("+"),
-  });
+  if (fullName.toLowerCase() === "get-bb/bb") continue; // bb itself, not a plugin
+
+  // The name search drags in other ecosystems' "bb-plugin" repos, and
+  // enumerating every one of them costs enough requests to hit the rate limit.
+  // A repo vouched for by a topic, by code search, by npm, or by a description
+  // that says "bb plugin" is read regardless of what it is called — that is the
+  // gate that used to drop bb-slop-cop.
+  const vouched = how.has("topic") || how.has("topic-getbb") || how.has("code") || how.has("npm") || how.has("description");
+  if (!vouched && !/bb[-_]?plugin/i.test(repo.name ?? fullName.split("/")[1])) { stats.skippedRepos++; continue; }
+
+  let units = [];
+  try {
+    units = await findPlugins(fullName, repo.default_branch ?? null);
+  } catch (e) {
+    // A repo we could not read is UNKNOWN, not empty. Say so rather than
+    // letting it vanish into the "not a plugin" pile.
+    console.error(`discover: could not read ${fullName} (${e.message}) — skipped, not judged`);
+    continue;
+  }
+  if (!units.length) { stats.skippedRepos++; continue; }
+  stats.plugins += units.length;
+
+  for (const u of units) {
+    const key = (u.path ? `${u.repo}/${u.path}` : u.repo).toLowerCase();
+    if (declined.has(key) || declined.has(u.repo.toLowerCase())) { stats.declined++; continue; }
+    if (isListed(u)) { stats.alreadyListed++; continue; }
+    candidates.push({
+      key,
+      fullName,
+      name: u.name,
+      url: u.path ? `https://github.com/${fullName}/tree/HEAD/${u.path}` : `https://github.com/${fullName}`,
+      stars: repo.stargazers_count ?? 0,
+      pushed: (repo.pushed_at ?? "").slice(0, 10),
+      desc: u.desc || (repo.description ?? "").replace(/\s+/g, " ").trim(),
+      why: u.why,
+      how: [...how].join("+"),
+      npm: u.pkgName,
+    });
+  }
 }
 
 // Always on stderr, even on a quiet week: "found nothing" and "looked at
 // nothing" are the same output otherwise, and the second one is a broken sweep
 // wearing the first one's face.
 console.error(
-  `discover: ${stats.searched} repos matched a search · ${stats.alreadyListed} already listed · ` +
-    `${stats.notAPlugin} not plugins · ${stats.archived} archived · ${candidates.length} new`,
+  `discover: ${stats.repos} repos matched a search · ${stats.skippedRepos} held no plugin · ` +
+    `${stats.private} private · ${stats.archived} archived · ${stats.plugins} plugins found · ` +
+    `${stats.alreadyListed} already listed · ${stats.declined} previously declined · ${candidates.length} new`,
 );
-if (stats.searched === 0) {
+if (stats.repos === 0) {
   console.error("discover: every search returned nothing — that is a broken sweep, not an empty ecosystem");
+  process.exit(1);
+}
+if (stats.plugins === 0) {
+  console.error("discover: matched repos but found zero plugins — the manifest check is broken, not the ecosystem");
   process.exit(1);
 }
 
 if (!candidates.length) process.exit(0); // silence is the normal week
 
-candidates.sort((a, b) => b.stars - a.stars || a.fullName.localeCompare(b.fullName));
+candidates.sort((a, b) => b.stars - a.stars || a.key.localeCompare(b.key));
 const lines = [
   `Found **${candidates.length}** bb plugin${candidates.length === 1 ? "" : "s"} not in the list yet.`,
   "",
-  "Each one was verified the same way the list requires — `package.json` has a `bb` key or",
-  "depends on `@bb/plugin-sdk` — so these are candidates, not guesses. They still need a",
+  "Each one was verified the same way the list requires — a manifest with a `bb` key or a",
+  "dependency on `@bb/plugin-sdk` — so these are candidates, not guesses. They still need a",
   "one-sentence description and the right section before they go in.",
   "",
+  "Something here that should **not** be listed? Add it to `discovery-ledger.json` with a reason",
+  "and the sweep will stop proposing it.",
+  "",
   ...candidates.map(
-    (c) => `- [ ] [${c.fullName}](${c.url}) — ${c.desc || "_no description_"}  \n      ` +
-      `<sub>${c.why} · found by ${c.how} · ${c.stars}★ · last push ${c.pushed}</sub>`,
+    (c) =>
+      `- [ ] [${c.name}](${c.url}) — ${c.desc || "_no description_"}  \n      ` +
+      `<sub>${c.why} · ${c.fullName}${c.npm ? ` · npm \`${c.npm}\`` : ""} · found by ${c.how} · ` +
+      `${c.stars}★ · last push ${c.pushed}</sub>`,
   ),
 ];
 console.log(lines.join("\n"));


### PR DESCRIPTION
The weekly sweep was working and the list still looked stale. `discover.mjs` asked *is this REPO a plugin?* and answered from the root `package.json`. Measured 2026-08-12: **11 candidates found, 36 that exist.**

### What was invisible

| Blind spot | Cost |
|---|---|
| Monorepo manifests at `plugins/<name>/package.json` | `smsunarto/bb-plugins` (9) + `MateoCerquetella/bb-plugins` (2) — both tagged `topic:bb-plugin`, both found, both discarded as \"not a plugin\" |
| \"Already listed\" decided per repo | `patleeman/bb-plugins` gaining `emoji-react`/`grove`, `jssblck/bb-plugins` gaining `goal` — unreportable by construction |
| Name gate ran before verification | `SawyerHood/bb-slop-cop` has a real `bb` key and was never read |
| npm was not a source | `keywords:bb-plugin` → 16 packages, each with a repo URL |

### Two things it turned up on the way

- **It was proposing private repos.** The sweep authenticates, so GitHub search returns the token owner\u2019s own private repos — four of mine were in today\u2019s candidates. A directory entry pointing at a private repo is a 404 for everyone but its owner; that is the breakage fd2338a had to clean up by hand.
- **The sweep ran *after* the thing that reads it.** repo-steward\u2019s Monday upkeep fires 00:20 Asia/Makassar = Sun 16:20 UTC, seventeen hours before a Mon 09:00 UTC sweep, so candidates waited a full week every week. Now daily.

### Also

`discovery-ledger.json` records judgements so they are not re-litigated weekly. README: the \"no bb plugins on npm yet\" claim is false now, and `galligan/bb-mate` → `galligan/bb-plugin-studio`.

### Verification

By falsification, not exit code: removing the `excalidraw` entry from README.md makes the sweep report it again — v1 structurally could not — and restoring it makes the sweep quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)