### PR TITLE
Judge all 29 candidates from the sweep: list 18, decline 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ entry lists one, that is the shorter route:
 bb plugin install npm:<package>
 ```
 
+A plugin living in a subdirectory of a monorepo cannot be installed with the `git:` form at
+all — bb reads the manifest at the repo root
+([get-bb/bb#1097](https://github.com/get-bb/bb/issues/1097)). Use the npm package where the
+entry names one, otherwise clone the repo and `bb plugin install <path>`.
+
 ([`@bb/plugin-sdk` itself is still unpublished](https://github.com/get-bb/bb/issues/1134);
 plugins vendor it. That blocks the SDK, not the plugins.)
 
@@ -38,6 +43,7 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 - [bb-plugin-kimi](https://github.com/vburojevic/bb-plugin-kimi) — Kimi Code as an ACP provider.
 - [bb-plugin-factory-droid](https://github.com/bentossell/bb-plugin-factory-droid) — Factory Droid as an ACP provider.
 - [omp](https://github.com/patleeman/bb-plugins) — OMP provider integration.
+- [amp](https://github.com/smsunarto/bb-plugins/tree/main/plugins/amp) — Amp as an ACP provider through a bundled bridge over the official `@ampcode/sdk`; `/orb` in a thread's first prompt runs it in an Amp Orb sandbox, and Oracle sub-agent calls render as a card with a streaming trace. · npm `@smsunarto/bb-plugin-amp`
 
 ## Threads & workflow
 
@@ -52,6 +58,12 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 - [auto-new-tab](https://github.com/patleeman/bb-plugins) · [sessions](https://github.com/patleeman/bb-plugins) · [prime-agent](https://github.com/patleeman/bb-plugins)
 - [bb-plugin-todo](https://github.com/agustif/bb-plugin-todo) — hierarchical session todos with nested sub-tasks, `dependsOn`/`requires`, and dispatch to multiple agents.
 - [bb-plugin-session-goal](https://github.com/agustif/bb-plugin-session-goal) — keeps a session's goal and success criteria on a composer card so they stay in view.
+- [agentation](https://github.com/smsunarto/bb-plugins/tree/main/plugins/agentation) — click any element of the bb UI, including another plugin's surface, and file it as an annotation carrying the route, owning plugin id and DOM selector; staged batches are assigned to a thread from its composer, and agent tools acknowledge, reply to and resolve them. · npm `@smsunarto/bb-plugin-agentation`
+- [t3sidebar](https://github.com/smsunarto/bb-plugins/tree/main/plugins/t3sidebar) — replaces the sidebar thread list with a flat inbox that never re-orders; snooze a thread to a wake time or settle it, which also archives it in bb, and live work blocks parking. Forked from bb's own `examples/plugins/t3sidebar` and built on experimental SDK slots. · npm `@smsunarto/bb-plugin-t3sidebar`
+- [Thread tasks](https://github.com/ariofrio/bb-plugins/tree/main/plugins/bb-plugin-thread-tasks) — replaces the sidebar thread list with manually ordered Done/To do/Working/Waiting/Deferred/Canceled sections, moves a thread to Working when its turn starts and back to To do when it stops or blocks on the user, and adds `.` status chords plus a `bb task list|show|update` CLI.
+- [Missing keyboard shortcuts](https://github.com/ariofrio/bb-plugins/tree/main/plugins/bb-plugin-missing-keyboard-shortcuts) — adds the shortcuts bb does not bind: ⌘[/⌘] for browser history, ⌘N/⇧⌘N for a new thread with or without the current thread's project, ⌘L to focus the primary composer, and ⇧⌘L / ⌃` to toggle a side chat or thread terminal.
+- [emoji-react](https://github.com/patleeman/bb-plugins) — adds one emoji button per configured reaction to the assistant-message text-selection menu; clicking one drafts a reply quoting the highlighted text.
+- [bb-plugin-writing-check](https://github.com/qiantao94/bb-plugin-writing-check) — checks each English message you send for spelling and grammar in a hidden worker thread and inserts the corrections below the message; explanations are written in Simplified Chinese.
 
 ## Editing & files
 
@@ -59,6 +71,7 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 - [bb-plugin-filetree](https://github.com/rekon307/bb-plugin-filetree) — lazy-loading file tree in the side panel.
 - [bb-plugin-md-annotate](https://github.com/DarrenTsung/bb-plugin-md-annotate) — Google-Docs-style inline comments on markdown.
 - [excalidraw](https://github.com/patleeman/bb-plugins) — Excalidraw boards inside bb.
+- [bb-plugin-excalidraw](https://github.com/Diffuzmetall/bb-plugin-excalidraw) — opens a workspace `.excalidraw` file as a canvas, with SHA-256 compare-and-swap agent tools, a `bb excalidraw` read/create/apply CLI, and a diagram-design skill. Third-party, despite the repo description calling it official.
 
 ## Code intelligence
 
@@ -74,6 +87,9 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 - [codex-environments](https://github.com/jssblck/bb-plugins) — Codex environment management.
 - [bb-plugin-accounts](https://github.com/MGrin/bb-plugin-accounts) — Claude Max account usage and auto-switching, with thread auto-continue after a rate limit.
 - [bb-plugin-cf-tunnel](https://github.com/MGrin/bb-plugin-cf-tunnel) — reach bb remotely over your own Cloudflare Tunnel and Access policy, with expiring shared ports.
+- [agent-proxy](https://github.com/smsunarto/bb-plugins/tree/main/plugins/agent-proxy) — installs CLIProxyAPI and keeps it running as a launchd/systemd login service, so several Claude and Codex accounts answer on one loopback OpenAI/Anthropic/Gemini endpoint; OAuth sign-in, provider keys, usage and Claude Code/Codex wiring in a panel, plus a `bb agent-proxy` CLI. It installs a third-party binary as a login service that outlives bb. · npm `@smsunarto/bb-plugin-agent-proxy`
+- [usage-tracker](https://github.com/MateoCerquetella/bb-plugins/tree/main/plugins/usage-tracker) — Codex and Claude Code usage percentages in a sidebar footer strip that expands to the 5-hour and weekly windows with reset times. · npm `bb-plugin-usage-tracker`
+- [bb-plugin-usage](https://github.com/MayankBansal12/bb-plugin-usage) — token counts and estimated API cost per agent, model provider and machine, read from Codex, Claude Code, Grok, OpenCode and Pi session logs on every enrolled host.
 
 ## Memory & knowledge
 
@@ -83,6 +99,7 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 
 - [bb-plugin-ios-notifications](https://github.com/vburojevic/bb-plugin-ios-notifications) — Web Push to your iPhone when a thread finishes or fails.
 - [bb-plugin-notify](https://github.com/agustif/bb-plugin-notify) — agent-to-user pings as an in-app toast or a webhook, with quiet hours.
+- [notify](https://github.com/smsunarto/bb-plugins/tree/main/plugins/notify) — native macOS notifications when a thread finishes or fails, posted by the bb window so they carry bb's icon and click through to the thread; holds them in a durable queue while bb is closed, plus a `notify_user` tool and a `bb notify` command. · npm `@smsunarto/bb-plugin-notify`
 
 ## Integrations
 
@@ -92,6 +109,9 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 - [bb-plugin-exec-tracking](https://github.com/pixexid/llm-collab) — records provider/model/reasoning evidence per run.
 - [bb-plugin-argocd](https://github.com/Willhong/bb-plugin-argocd) — read-only Argo CD browser: application sync and health, managed resources, deploy history and pod logs, with agent tools and a `bb argocd` CLI.
 - [bb-plugin-jenkins](https://github.com/Willhong/bb-plugin-jenkins) — Jenkins jobs, builds and console logs as a panel, with agent tools, a `bb jenkins` CLI, and build triggering behind a confirmation.
+- [bb-slop-cop](https://github.com/SawyerHood/bb-slop-cop) — polls GitHub for PRs matching rules you define, dispatches a bb agent to review each match, and posts the review with `gh`; new rules run in shadow mode and only review authors with write access.
+- [gh-stack](https://github.com/smsunarto/bb-plugins/tree/main/plugins/gh-stack) — drives `gh stack` in a thread's workspace: a layer rail with each PR's state and `+N −M` diff, checkout with auto-stash, draft toggle, sync/submit/merge/prune, and a button that hands the split to the thread's agent. · npm `@smsunarto/bb-plugin-gh-stack`
+- [taskboard](https://github.com/MateoCerquetella/bb-plugins/tree/main/plugins/taskboard) — per-project GitHub, Linear or Jira issues as a list or kanban board, with drag-to-move through the provider's own statuses, a `bb taskboard` CLI, and a mention that attaches a task's context to a prompt. · npm `bb-plugin-taskboard`
 
 ## Appearance
 
@@ -99,6 +119,9 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 - [bb-plugin-sidebar-sync](https://github.com/MGrin/bb-plugin-sidebar-sync) — keeps the sidebar arrangement — nav order, hidden rows, collapsed sections — the same in every bb UI; width and open state stay per-device.
 - [ds4](https://github.com/patleeman/bb-plugins) — design-system theming.
 - [bb-plugin-fontsize](https://github.com/jmporchet/bb-plugin-fontsize) — scales the whole interface from a sidebar footer button that cycles 13/16/20/26px, plus a settings panel with ±1px control; the size is stored per device.
+- [monokai](https://github.com/smsunarto/bb-plugins/tree/main/plugins/monokai) — dark Monokai palette that also repaints the terminal's 16 ANSI colors, the diff viewer's rows and gutters, the file tree's git-status column, inline code tokens and the composer stop button; dark appearance only. · npm `@smsunarto/bb-plugin-monokai`
+- [Project header breadcrumb](https://github.com/ariofrio/bb-plugins/tree/main/plugins/bb-plugin-project-header-breadcrumb) — puts the project name before the thread title, with a menu for project settings, rename and remove.
+- [Project icons](https://github.com/ariofrio/bb-plugins/tree/main/plugins/bb-plugin-project-icons) — gives each project an icon and optional color, picked from a 2,532-icon Hugeicons catalog and drawn before the project name in the thread header.
 
 ## Fun
 

--- a/discovery-ledger.json
+++ b/discovery-ledger.json
@@ -19,6 +19,61 @@
       "plugin": "smsunarto/bb-plugins/plugins/pr-walkthrough",
       "reason": "Its own package.json description opens 'WORK IN PROGRESS — unfinished and unsupported'. The author is saying not to depend on it yet; the list should not say otherwise. Remove this entry when that wording goes.",
       "at": "2026-08-12"
+    },
+    {
+      "plugin": "amrtawfik160/hanoon",
+      "reason": "Real plugin, well built (SQLite control plane, FTS5 memory, reviewed pipeline with one-use approvals, 21 agent tools, 71 test files), and nothing else on the list drives bb from Telegram. Declined on trust: package.json sets 'private: true' (blocks installation, and its own quick start only documents a local 'bb plugin install .'), there is NO LICENSE file at all, and the repo was two days old with 6 commits when read. It hands whoever holds a Telegram chat full-permission shell and bb CLI across every connected machine — its own README says to use a disposable repo for the first live run. Re-propose once it has a license, 'private' removed, and a real commit history.",
+      "at": "2026-08-12"
+    },
+    {
+      "plugin": "smsunarto/bb-plugins/plugins/dotfiles",
+      "reason": "The author disqualifies it: the README badge reads 'status: personal · unsupported' and 'Not published to npm. Personal tooling, unsupported for external use... written against one specific dotfiles repository layout. Against a differently shaped repo, every row reads missing and every task fails.' package.json is 'private: true'. The file registry and fourteen mise task names are hardcoded to that author's repo, so a stranger installs a panel of red 'missing' badges. Not a code-quality complaint.",
+      "at": "2026-08-12"
+    },
+    {
+      "plugin": "brsbl/bb-plugins/packages/thread-history-maintenance",
+      "reason": "Not a plugin — an internal shared library. package.json is 'private: true', has no bb key, declares no server or app surface, and carries @bb/plugin-sdk only as a devDependency for types; index.ts exports one factory. The repo's own packages/README.md calls it 'the shared idle-episode queue used by Improve Prompt and Design Doctrine'. Genuine engineering (1085 lines plus 609 of vitest), just not something a reader can install. The actual plugins in that repo are listed separately.",
+      "at": "2026-08-12"
+    },
+    {
+      "plugin": "gmemmanuel/bbonductor",
+      "reason": "Its central claim does not hold. The pitch is many threads per branch/worktree, but the sidebar's '+ New thread in this workspace' calls openNewThread({projectId}) with no environment seed, so the thread lands wherever bb would have put it anyway; createWorkspaceFromLinear spawns into project-default rather than an issue-named worktree. The README lists both as the top unfinished items and docs/IMPLEMENTATION-NOTES.md opens 'Must validate against a live BB install'. v0.1.0-alpha.1, all 22 commits inside a ten-minute window on 2026-08-08, no tests, no CI. Re-propose once the existing-environment spawn works and it has run against a live bb.",
+      "at": "2026-08-12"
+    },
+    {
+      "plugin": "sudohackin/bb-plugin-symphony-task",
+      "reason": "Overwhelmingly a vendored fork of the Tasks plugin bb already ships, and it keeps upstream's identity rather than sitting beside it: it registers a CLI literally named 'tasks' with the same 15 subcommands and a navPanel id 'tasks'/title 'Tasks'/icon 'ListTodo', so installing it collides with a plugin every bb install already has enabled. The import commit landed 113 files and +49,126 lines; file-for-file diffs against get-bb/bb plugins/tasks are near-identical (tasks-editor.tsx 642 lines both sides, 6 differing lines, all import-path rewrites). Upstream is MIT and the LICENSE was dropped; upstream's tests were deleted. The author's own additions (Jira source, Beads source, execution engine, ~5,700 lines) are real — extracted as a plugin that composes with bb's Tasks instead of replacing it, that would be a different and plausibly listable thing.",
+      "at": "2026-08-12"
+    },
+    {
+      "plugin": "dbrekelmans/bb-orchestra",
+      "reason": "Real plugin, genuinely distinct (cross-provider delegation to child threads with per-worker provider/model/effort, seven agent tools, a reconciler, 70 tests checked against deliberate mutations). Declined only on trust-for-a-stranger: the README has a '## Status' section reading 'Prototype' which discloses that orchestra_tell and the panel's '+ New' have never run against a live provider and that the 'bb plugin install git:' line it gives readers has not been tested end to end — that is the first thing a reader from this list would run, on full-trust code. 5 commits all on 2026-08-07, nothing since, no LICENSE. A verified git install plus a few weeks of the repo staying alive flips this; it would go under Threads & workflow.",
+      "at": "2026-08-12"
+    },
+    {
+      "plugin": "joesirven/bb-plugin-evals",
+      "reason": "Both headline invariants are genuinely implemented (no filesystem write path in server.ts at all; a run is recorded as 'refused' when the sealed manifest hash drifts). Declined on maintenance and scope: the README says 'This plugin is a prototype living in a personal fork for now' and plans to propose it upstream into bb within about a week, which would make a list entry stale by design; two commits, both 2026-08-07, no CI. Its 'bb evals check' is also hardcoded to one private knowledge base's layout (00-OPS/AGENTS-LOG.md, 01-ARCHITECTURE/ADRs/, a bespoke commit-message regex), so the deterministic layer does not apply to a stranger's repo.",
+      "at": "2026-08-12"
+    },
+    {
+      "plugin": "kaviisuri/bb-plugin-tasks",
+      "reason": "A vendored copy of a plugin bb already ships. Its own README opens 'A customisable build of BB's Tasks plugin... Upstream source is vendored byte-for-byte', and .upstream-ref names ymichael/bb, tag desktop-v0.35.1, path official-plugins/tasks. package.json is 'private: true', the plugin id 'tasks' is reserved by the bundled one, and the documented install is 'cp -R ~/.bb/plugins/tasks/ ~/.bb/plugins/tasks-kv/' plus 'bb plugin disable tasks' — hand-migrating the builtin's live task database. The work on top (task dependencies/blocking plus subtask views, ~6,500 lines with vitest coverage) is real; re-propose if it ships standalone with its own plugin id and no manual data migration.",
+      "at": "2026-08-12"
+    },
+    {
+      "plugin": "mayankbansal12/bb-plugin-web-push-notify",
+      "reason": "Not Web Push: no service worker, no VAPID, no push subscription. It is a 2.5s poll against an in-memory ring buffer in the server process (lost on restart) driving the foreground Notification API, so nothing arrives unless a bb tab is open. The README says so honestly; the repo NAME does not, and the entry would sit directly under bb-plugin-ios-notifications, which is actual Web Push. Also created 2026-08-11 with 4 commits, no LICENSE, and its own settings UI says 'Phase 1 delivers notifications while BB is open in this browser'. Code quality is good (strict TS, zod-validated RPC, vitest, green CI). Worth re-proposing with commits behind it, ideally under a name that does not say 'web push'.",
+      "at": "2026-08-12"
+    },
+    {
+      "plugin": "patleeman/bb-plugins/packages/bb-plugin-grove",
+      "reason": "Substantial and real (~3,500 lines, SHA-256 compare-and-swap on every agent write, dictation through bb's own voice-transcription endpoint, four CLI subcommands, three app slots, a genuine test suite) and distinct from the Editing & files entries. Declined on maintenance, in the author's own words: the single commit that introduces it (e7473a6, 2026-08-09) is a multi-package checkpoint whose body reads 'Also includes in-flight WIP: bb-plugin-grove...'. That is the package's entire history — no follow-up, no iteration. Its README install command is also hardcoded to /Users/patrick/workingdir/. Re-propose once it has history beyond the checkpoint that called it in-flight.",
+      "at": "2026-08-12"
+    },
+    {
+      "plugin": "pierback/bb-session-fabric",
+      "reason": "Not a plugin for bb. Every server call goes through bb.sdk.sessionFabric, a capability that exists only in the author's own fork (pierback/bb, forked from get-bb/bb 2026-08-11). Generating the SDK declarations against bb 0.37.0 gives zero occurrences of sessionFabric, so requireSessionFabricCapability() throws on load and the plugin does nothing on a real bb; its engines.bb is '>=0.36 <0.37', which the current release does not satisfy either. The README states it requires 'Pierback BB 0.36.x' and 'deliberately has no fallback for upstream BB builds'. Reconsider if sessionFabric lands in upstream bb.",
+      "at": "2026-08-12"
     }
   ],
   "listedAs": []


### PR DESCRIPTION
Acts on every one of the 29 candidates in #4. Each was read at the source — manifest, server, app, tests, npm registry, repo metadata — before the verdict, and each verdict is written down where the sweep can see it, because a judgement that is not recorded gets made again next week.

**Listed (18).** `amp`, `agentation`, `t3sidebar`, `agent-proxy`, `notify`, `gh-stack`, `monokai` (smsunarto) · `taskboard`, `usage-tracker` (MateoCerquetella) · `thread-tasks`, `missing-keyboard-shortcuts`, `project-header-breadcrumb`, `project-icons` (ariofrio) · `bb-slop-cop` · `bb-plugin-usage` · `bb-plugin-excalidraw` · `emoji-react` · `writing-check`.

**Declined (11)**, each with a reason in `discovery-ledger.json`: `hanoon` and smsunarto's `dotfiles` (`private: true`, unsupported by their own authors) · `thread-history-maintenance` (a shared library, not a plugin — no `bb` key, no surfaces) · `bbonductor` (its central claim, many threads per worktree, is not implemented) · `symphony-task` and `KaviiSuri/tasks` (vendored forks of bb's bundled Tasks plugin, taking its CLI name and panel id) · `orchestra`, `evals`, `web-push-notify`, `grove` (prototype/WIP by the author's own words) · `session-fabric` (needs `bb.sdk.sessionFabric`, which exists only in the author's fork of bb — it throws on load against bb 0.37.0).

Most declines are "not yet" rather than "no"; the ledger says for each what would change the answer.

Two corrections that fell out of reading the source:

- A plugin in a monorepo subdirectory **cannot** be installed with the `git:` form the README leads with (get-bb/bb#1097). That now applies to 13 entries, so the install section says so and the entries name their npm package where one exists.
- npm names were verified against the registry, not taken from the sweep: `bb-plugin-slopcop` 404s, so the SlopCop entry carries the git form only.

Checked with a local replay of `scripts/discover.mjs`'s own `isListed`/`declined` matching: all 29 resolve, so the next sweep should report nothing new. All 19 added links return 200.

Only `README.md` and `discovery-ledger.json` change — no scripts, workflows or CI.
