### PR TITLE
Drop the stale "repo description says official" note on bb-plugin-excalidraw

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 - [bb-plugin-filetree](https://github.com/rekon307/bb-plugin-filetree) — lazy-loading file tree in the side panel.
 - [bb-plugin-md-annotate](https://github.com/DarrenTsung/bb-plugin-md-annotate) — Google-Docs-style inline comments on markdown.
 - [excalidraw](https://github.com/patleeman/bb-plugins) — Excalidraw boards inside bb.
-- [bb-plugin-excalidraw](https://github.com/Diffuzmetall/bb-plugin-excalidraw) — opens a workspace `.excalidraw` file as a canvas, with SHA-256 compare-and-swap agent tools, a `bb excalidraw` read/create/apply CLI, and a diagram-design skill. Third-party, despite the repo description calling it official.
+- [bb-plugin-excalidraw](https://github.com/Diffuzmetall/bb-plugin-excalidraw) — opens a workspace `.excalidraw` file as a canvas, with SHA-256 compare-and-swap agent tools, a `bb excalidraw` read/create/apply CLI, and a diagram-design skill.
 
 ## Code intelligence
 


### PR DESCRIPTION
@Diffuzmetall fixed the repository description after #4, so the caveat in the entry no longer describes anything a reader would run into. The description now reads:

> Third-party Excalidraw plugin for BB: view, edit, and safely automate drawings stored as canonical workspace files, with SHA-256 compare-and-swap on every agent write.

Verified via `gh api repos/Diffuzmetall/bb-plugin-excalidraw`.

This also closes the one thing I left unverified in #4 — whether `private: true` breaks the documented install. It does not. Fresh clone, then the installer's exact steps:

```
npm install --omit=dev --omit=optional --ignore-scripts
bb plugin build .
```

exits 0 and writes `dist/server.js`, `dist/app.js`, `dist/app.css`. `private` only gates `npm publish`.

The rest of the entry is unchanged and still distinguishes it from patleeman's `excalidraw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)