### PR TITLE
Note Wterm's experimental-slot coupling and where uploads land

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 ## Host & environment
 
 - [bb-plugin-system](https://github.com/MGrin/bb-plugin-system) — CPU, memory, disk and top processes as a panel, homepage tiles and a `bb system` CLI.
-- [Wterm Terminal Preview](https://github.com/Diffuzmetall/bb-wterm-terminal-plugin) — early-preview Ghostty-backed alternative to bb's thread terminal with persistent reattachment, TUI mouse input, font controls and file upload for SSH and Herdr workflows.
+- [Wterm Terminal Preview](https://github.com/Diffuzmetall/bb-wterm-terminal-plugin) — early-preview Ghostty-backed alternative to bb's thread terminal with persistent reattachment, TUI mouse input, font controls and file upload for SSH and Herdr workflows. Drives bb's own terminal sessions rather than spawning its own, and uploads land in `.bb-wterm-uploads/` under the terminal's working directory. Built on an experimental SDK slot, so it is more exposed to bb UI churn than most entries.
 - [bb-plugin-worktree-setup](https://github.com/KaviiSuri/bb-plugin-worktree-setup) — per-repo worktree provisioning and git hooks.
 - [browser](https://github.com/jssblck/bb-plugins) — shared Chrome over CDP.
 - [bb-plugin-browser](https://github.com/MGrin/bb-plugin-browser) — drives a browser you already have (Brave, Chrome, Chromium, Edge, Vivaldi or Opera) over CDP on a profile of its own, headless by default; each thread gets its own tab named by CDP target id, so tabs survive plugin reloads and bb restarts, threads share cookies and logins but can never move each other's page, `browser_show` relaunches on screen when a login wall or CAPTCHA needs you, and the idle reaper only ever closes tabs the plugin opened.


### PR DESCRIPTION
Follow-up to #10, which is merged as 814212c — @Diffuzmetall's entry and commit stand as written. This only appends two facts I turned up reviewing the source, both of the kind the list already records elsewhere.

**Experimental SDK slot.** `app.tsx:321` registers via `app.slots.threadPanelAction`, with `experimental_useReplaceCurrentPluginTab` at `:331`. The `t3sidebar` entry carries the same caveat and `Missing keyboard shortcuts` carries a stronger one, so this is consistency rather than a new rule.

**Where uploads go.** `handleUpload` in `server.ts` writes to `.bb-wterm-uploads/<uuid>.<ext>` under the terminal's `initialCwd` — inside your working tree, so it can show up in `git status`. Worth knowing before you drop a file on it.

**Drives bb's own terminals.** `server.ts` calls `bb.sdk.terminals.list/create/restart` and never spawns a PTY itself, which is the reassuring half of the same finding — it is not a second privilege path into the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)