### PR TITLE
Verify npm names against the registry instead of asserting them

### DIFF
--- a/scripts/discover.mjs
+++ b/scripts/discover.mjs
@@ -137,6 +137,37 @@ async function searchRepos() {
   return found;
 }
 
+// A package.json `name` is what the author INTENDS to publish, not what is
+// published. Reporting it as an npm package without asking the registry was
+// wrong 21 times out of 22 on 2026-08-15, and wrong about bb-plugin-slopcop on
+// 2026-08-12. It matters because a plugin in a monorepo subdirectory cannot be
+// installed with the `git:` form at all (get-bb/bb#1097), so for those the npm
+// name is the ONLY install route an entry can offer — and a fabricated one
+// sends the reader to a command that cannot work.
+//
+// Unknown is not the same as absent: a registry that times out must not silently
+// turn every package into a 404, so a failed lookup returns null and the caller
+// omits the claim rather than asserting either way.
+const npmCache = new Map();
+async function publishedOnNpm(name) {
+  if (!name) return false;
+  if (npmCache.has(name)) return npmCache.get(name);
+  let verdict = null;
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${name.replace("/", "%2F")}`, {
+      method: "HEAD",
+      headers: { "user-agent": "awesome-bb-plugins-discover" },
+    });
+    if (res.status === 200) verdict = true;
+    else if (res.status === 404) verdict = false;
+    // Anything else (429, 5xx) stays null — unknown, not absent.
+  } catch {
+    // Network failure is unknown too.
+  }
+  npmCache.set(name, verdict);
+  return verdict;
+}
+
 const isPluginManifest = (pkg) => {
   if (pkg?.bb) return { ok: true, why: "package.json has a bb key", desc: pkg.bb?.description ?? pkg.description ?? null };
   const deps = { ...(pkg?.dependencies ?? {}), ...(pkg?.devDependencies ?? {}), ...(pkg?.peerDependencies ?? {}) };
@@ -291,6 +322,7 @@ for (const [fullName, { repo: found0, how }] of found) {
     candidates.push({
       key,
       fullName,
+      path: u.path,
       name: u.name,
       url: u.path ? `https://github.com/${fullName}/tree/HEAD/${u.path}` : `https://github.com/${fullName}`,
       stars: repo.stargazers_count ?? 0,
@@ -298,9 +330,29 @@ for (const [fullName, { repo: found0, how }] of found) {
       desc: u.desc || (repo.description ?? "").replace(/\s+/g, " ").trim(),
       why: u.why,
       how: [...how].join("+"),
-      npm: u.pkgName,
+      // Verified against the registry below, once the candidate list is final —
+      // never taken from the manifest.
+      npm: null,
+      pkgName: u.pkgName,
     });
   }
+}
+
+// Resolve the npm claims now that the candidate list is final — a handful of
+// HEAD requests, not one per plugin in the ecosystem.
+let npmChecked = 0;
+let npmUnknown = 0;
+for (const c of candidates) {
+  const verdict = await publishedOnNpm(c.pkgName);
+  if (verdict === null) npmUnknown++;
+  else if (verdict) npmChecked++;
+  c.npm = verdict === true ? c.pkgName : null;
+}
+if (candidates.length) {
+  console.error(
+    `discover: npm — ${npmChecked} of ${candidates.length} candidate package names are really published` +
+      (npmUnknown ? `, ${npmUnknown} unknown (registry did not answer; claim omitted)` : ""),
+  );
 }
 
 // Always on stderr, even on a quiet week: "found nothing" and "looked at
@@ -336,8 +388,12 @@ const lines = [
   ...candidates.map(
     (c) =>
       `- [ ] [${c.name}](${c.url}) — ${c.desc || "_no description_"}  \n      ` +
-      `<sub>${c.why} · ${c.fullName}${c.npm ? ` · npm \`${c.npm}\`` : ""} · found by ${c.how} · ` +
-      `${c.stars}★ · last push ${c.pushed}</sub>`,
+      `<sub>${c.why} · ${c.fullName}${c.npm ? ` · npm \`${c.npm}\`` : ""}` +
+      // A subdirectory plugin cannot use the `git:` form (get-bb/bb#1097). With
+      // no npm package either, there is no documented install route at all —
+      // say so here rather than leaving whoever triages it to find out.
+      `${c.path && !c.npm ? " · **no install route: monorepo subdir, not on npm**" : ""}` +
+      ` · found by ${c.how} · ${c.stars}★ · last push ${c.pushed}</sub>`,
   ),
 ];
 console.log(lines.join("\n"));


### PR DESCRIPTION
Fixes the sweep bug found while triaging #9. Refs MX-90.

## The bug

`discover.mjs` printed `npm \`<name>\`` for every candidate, read straight from the plugin's `package.json` `name` and never checked against the registry. A `name` field is what an author *intends* to publish, not what is published.

**21 of the 22 names reported in #9 were 404s** — only `bb-plugin-t3sidebar` was real. The same defect produced the wrong `bb-plugin-slopcop` claim in #4. Both times a human had to check the registry by hand to avoid publishing an install command that fails.

It is not cosmetic: a plugin in a monorepo subdirectory **cannot use the `git:` form at all** (get-bb/bb#1097), so for those the npm name is the only install route an entry can offer.

## The fix

`publishedOnNpm()` HEADs `registry.npmjs.org` once per candidate name, cached, after the candidate list is final — a handful of requests, not one per plugin in the ecosystem.

**Unknown stays distinct from absent.** A 429, a 5xx or a network failure returns `null`, and the claim is omitted rather than the package being declared missing. A registry that times out must not silently turn every package into a 404.

Also adds the thing a triager otherwise has to discover for themselves: a monorepo subdirectory with no npm package has no documented install route at all, and the row now says so.

## Verified end to end, against live GitHub and npm

Real run on current `main`:

```
discover: 397 repos matched a search · 294 held no plugin · 7 private · 32 archived ·
          93 plugins found · 79 already listed · 14 previously declined · 0 new
```

Exit 0, empty report — so tomorrow's 06:00 sweep stays quiet, which also independently confirms #12 closed the loop (79 + 14 = 93, nothing unaccounted).

Scratch run with four entries removed to force candidates through the new path:

```
discover: npm — 1 of 4 candidate package names are really published
```

- `T3 Sidebar` (really published) → renders `· npm \`bb-plugin-t3sidebar\``
- `Cobalt2` (monorepo subdir, unpublished) → renders `**no install route: monorepo subdir, not on npm**`
- `Server File Explorer` and `Pets` (standalone, unpublished) → render neither, correctly, since `git:` works for them

Before this change all four would have carried an npm claim and three would have been false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)