### PR TITLE
Judge six from #16: list three, decline three that cannot be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 
 ## Threads & workflow
 
+
+- [Stale Resume](https://github.com/yegor-korobeynikov/bb-plugin-stale-resume) — catches the failure where a thread's Claude Code session file no longer exists once its working directory has changed, tells the parent thread instead of leaving the child silently dead, and brings it back with `bb stale-resume recover`; `check` and `status` from the same CLI.
 - [bb-plugin-advisor](https://github.com/salemsayed/bb-plugin-advisor) — reviews a coding thread with a second model in a hidden reviewer thread; a pre-final agent tool plus post-turn review, with findings that re-raise across turns until the reviewer re-checks and closes them.
 - [bb-plugin-bus](https://github.com/MGrin/bb-plugin-bus) — peer messaging between threads; addressed sends wake the recipient with a real turn, so no listener process is needed.
 - [bb-plugin-auto-sections](https://github.com/benegessarit/bb-plugin-auto-sections) — files task-keyed threads into sidebar sections automatically.
@@ -145,6 +147,8 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 
 ## Host & environment
 
+
+- [Terminal Jobs](https://github.com/ryanbbrown/bb-plugin-terminal-jobs) — runs a long terminal command as a durable job: state in the plugin's own SQLite, artifacts written on the target host, and an at-least-once completion notice delivered to one immutable owner thread, so the verdict outlives the session that started it. Backend only — `bb terminal-job run|watch|show|retry-notification` and a `terminal-jobs` skill, with no panel, HTTP route or agent tool.
 - [bb-plugin-system](https://github.com/MGrin/bb-plugin-system) — CPU, memory, disk and top processes as a panel, homepage tiles and a `bb system` CLI.
 - [Wterm Terminal Preview](https://github.com/Diffuzmetall/bb-wterm-terminal-plugin) — early-preview Ghostty-backed alternative to bb's thread terminal with persistent reattachment, TUI mouse input, font controls and file upload for SSH and Herdr workflows. Drives bb's own terminal sessions rather than spawning its own, and uploads land in `.bb-wterm-uploads/` under the terminal's working directory. Built on an experimental SDK slot, so it is more exposed to bb UI churn than most entries.
 - [bb-plugin-worktree-setup](https://github.com/KaviiSuri/bb-plugin-worktree-setup) — per-repo worktree provisioning and git hooks.
@@ -186,6 +190,8 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 
 ## Notifications
 
+
+- [ntfy notifications](https://github.com/slogsdon/bb-plugin-ntfy) — pushes to your phone through [ntfy.sh](https://ntfy.sh) when a thread needs your attention, with `bb ntfy test|status` to check the wiring. The topic is a secret setting, which is the right call: on ntfy the topic name is the only thing between your notifications and anyone who guesses it.
 - [bb-plugin-ios-notifications](https://github.com/vburojevic/bb-plugin-ios-notifications) — Web Push to your iPhone when a thread finishes or fails.
 - [bb-plugin-notify](https://github.com/agustif/bb-plugin-notify) — agent-to-user pings as an in-app toast or a webhook, with quiet hours.
 - [notify](https://github.com/smsunarto/bb-plugins/tree/main/plugins/notify) — native macOS notifications when a thread finishes or fails, posted by the bb window so they carry bb's icon and click through to the thread; holds them in a durable queue while bb is closed, plus a `notify_user` tool and a `bb notify` command. · npm `@smsunarto/bb-plugin-notify`

--- a/discovery-ledger.json
+++ b/discovery-ledger.json
@@ -219,6 +219,21 @@
       "plugin": "hmps/bb-plugins/plugins/github-plus",
       "reason": "An explicit vendored fork of bb's builtin github plugin, which is an exclusion. Its own README states 'This plugin is a fork of bb's builtin github plugin, version 0.2.1' and tells you to `bb plugin disable github` first to avoid duplicate panels, mentions and CLI. The implementation is substantial and real (1736-line server, gh-CLI auth, 5-minute background sync into SQLite, zod-validated rpc contract) — the ground is the vendored-copy rule, not quality. It is also absent from the repo's own marketplace.json, so the author has not published it. Re-propose if it stops being a fork of the bundled plugin, or if bb drops the builtin.",
       "at": "2026-08-31"
+    },
+    {
+      "plugin": "portseif/bb-plugin-project-hub",
+      "reason": "Not installable. server.ts:its zod import imports zod, but zod is in devDependencies, and `bb plugin install git:` runs `npm install --omit=dev` — so the build dies on `Could not resolve \"zod\"` and nothing installs. Reproduced in a fresh clone on 2026-08-31 with the installer's exact steps against bb 0.40.0. One line in package.json fixes it. Re-propose once it builds; nothing else was held against it.",
+      "at": "2026-08-31"
+    },
+    {
+      "plugin": "portseif/bb-plugin-sidebar-folders",
+      "reason": "Not installable. server.ts:its zod import imports zod, but zod is in devDependencies, and `bb plugin install git:` runs `npm install --omit=dev` — so the build dies on `Could not resolve \"zod\"` and nothing installs. Reproduced in a fresh clone on 2026-08-31 with the installer's exact steps against bb 0.40.0. One line in package.json fixes it. Re-propose once it builds; nothing else was held against it.",
+      "at": "2026-08-31"
+    },
+    {
+      "plugin": "yhterrance/bb-plugin-usage",
+      "reason": "Not installable. server.ts:its zod import imports zod, but zod is in devDependencies, and `bb plugin install git:` runs `npm install --omit=dev` — so the build dies on `Could not resolve \"zod\"` and nothing installs. Reproduced in a fresh clone on 2026-08-31 with the installer's exact steps against bb 0.40.0. One line in package.json fixes it. Re-propose once it builds; nothing else was held against it.",
+      "at": "2026-08-31"
     }
   ],
   "listedAs": [


### PR DESCRIPTION
A bounded batch off the 104 unjudged candidates in #16.

## How these six were chosen

Rather than picking by stars — 92 of the 104 have zero, so it is no signal — I pre-screened **all 104** for the breakage that has already kept four plugins off this list: a runtime `zod` import declared only in `devDependencies`, which `npm install --omit=dev` then cannot resolve.

Eleven declare it that way. Five are monorepo subpackages where deps can legitimately live at the workspace root, so the screen is not decisive there. The remaining **six standalone repos were built**.

## Declined — 3, none installable

Reproduced in a fresh clone with the installer's exact steps, bb 0.40.0:

- [portseif/bb-plugin-project-hub](https://github.com/portseif/bb-plugin-project-hub)
- [portseif/bb-plugin-sidebar-folders](https://github.com/portseif/bb-plugin-sidebar-folders)
- [yhterrance/bb-plugin-usage](https://github.com/yhterrance/bb-plugin-usage)

All three: `Could not resolve "zod"`, no `dist/server.js`. One line each. Recorded in `discovery-ledger.json` as "not yet" with the repro.

## Listed — 3

- **Terminal Jobs** → Host & environment. Durable terminal jobs with state in the plugin's SQLite and an at-least-once completion notice to one immutable owner thread. Backend only — no panel, HTTP route or agent tool, which the entry says.
- **ntfy notifications** → Notifications. Phone push via ntfy.sh; topic held as a secret setting, which is correct — on ntfy the topic name *is* the credential.
- **Stale Resume** → Threads & workflow. Catches a thread whose Claude Code session file vanished after its working directory changed, reports it to the parent instead of leaving the child silently dead.

## The screen was only 50% precise

Three of the six flagged repos build fine — `zod` is shimmed or unused on the server path. So each was built rather than judged from its manifest. Worth stating because the manifest check on its own would have produced three wrong declines.

## What is left

**98 of the 104 remain unjudged**, and there is no cheap way to cut them: none is archived, private, gone, a fork, or missing a `bb` key, and the sweep's own matcher confirms none is already listed. **48 of the 104 ship no LICENSE**, which is a judgement call per entry rather than an automatic decline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)