### PR TITLE
Say that VS Code Server needs a server you already run

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Plugins are full-trust code running in the bb server. Read the source before ins
 
 - [bb-plugin-files](https://github.com/Diffuzmetall/bb-plugin-files) — file browser and editor for a thread's environment.
 - [bb-plugin-filetree](https://github.com/rekon307/bb-plugin-filetree) — lazy-loading file tree in the side panel.
-- [VS Code Server](https://github.com/GantisStorm/bb-plugin-vscode-server) — embeds a configured code-server or VS Code Server instance in a thread's right panel, opening at the thread workspace or storage folder.
+- [VS Code Server](https://github.com/GantisStorm/bb-plugin-vscode-server) — embeds a code-server or VS Code Server instance in a thread's right panel as an iframe, opening at the thread's workspace or storage folder via `?folder=`. It does not start a server: you run one yourself and give the plugin its URL in settings, so the server also has to permit being framed.
 - [Git Graph](https://github.com/GabZoFar/bb-plugin-git-graph) — read-only commit graph in a thread side panel, running git inside that thread's own environment — including one hosted on another connected machine, rather than on whichever repo the bb window happens to be pointing at.
 - [bb-plugin-md-annotate](https://github.com/DarrenTsung/bb-plugin-md-annotate) — Google-Docs-style inline comments on markdown.
 - [excalidraw](https://github.com/patleeman/bb-plugins/tree/main/packages/bb-plugin-excalidraw) — create and edit Excalidraw drawings, then attach them to a conversation.


### PR DESCRIPTION
Follow-up to #31, which is merged and whose stated claims all check out.

The entry read "embeds a **configured** code-server or VS Code Server instance". True, and easy to read as the plugin providing one.

**It does not.** There is no `child_process`, `spawn`, `execFile` or `exec` anywhere in the source. It defines a `serverUrl` string setting (`server.ts:163`) and renders an **iframe** at that URL with `?folder=` pointing at the thread's workspace or storage location. Its bb surfaces are `bb.settings.define`, `bb.rpc.register`, `bb.sdk.threads.get`, `bb.sdk.threads.storageLocation`, `bb.sdk.environments.get` and `bb.storage.kv.*` — nothing that could start a process.

So the prerequisite is a code-server the reader runs themselves. Same omission #26 fixed for Mane Control's Ponytail dependency: a reader installs it, has nothing to point it at, and concludes the plugin is broken.

One further clause, because it is not obvious from "embeds": it is an **iframe**, so the server has to permit being framed. Someone running code-server behind default headers otherwise gets a blank panel and blames the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)